### PR TITLE
Add the `version()` and `cdm_version` functions; don't export `CDM_VERSION`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0-DEV"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 DataFrames = "0.21"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,4 +4,4 @@ CurrentModule = OMOPCommonDataModel
 
 # OMOPCommonDataModel
 
-[OMOPCommonDataModel.jl](https://github.com/JuliaHealth/OMOPCommonDataModel.jl) is a pure Julia implementation of the [OMOP Common Data Model (CDM)](https://github.com/OHDSI/CommonDataModel).
+[`OMOPCommonDataModel.jl`](https://github.com/JuliaHealth/OMOPCommonDataModel.jl) is a pure Julia implementation of the [OMOP Common Data Model (CDM)](https://github.com/OHDSI/CommonDataModel).

--- a/docs/src/version.md
+++ b/docs/src/version.md
@@ -4,17 +4,34 @@ CurrentModule = OMOPCommonDataModel
 
 # CDM Version
 
-The following table maps the version of OMOPCommonDataModel.jl to the
-corresponding version of the Common Data Model (CDM).
+The following table shows which version of the OMOP Common Data Model (CDM) is
+implemented in each version of the `OMOPCommonDataModel.jl` Julia package.
 
-| OMOPCommonDataModel.jl | CDM    |
-| ---------------------- | ------ |
-| 0.1.0                  | 6.0.0  |
+| Common Data Model (CDM) | `OMOPCommonDataModel.jl` |
+| ----------------------- | ------------------------ |
+| 6.0.0                   | 0.1.0                    |
 
-In order to see the current CDM version, use the `OMOPCommonDataModel.CDM_VERSION` constant:
+In order to see the current CDM version, use the
+`OMOPCommonDataModel.cdm_version` function:
 ```jldoctest
 julia> using OMOPCommonDataModel
 
-julia> OMOPCommonDataModel.CDM_VERSION
+julia> OMOPCommonDataModel.cdm_version()
 v"6.0.0"
 ```
+
+In order to see the current `OMOPCommonDataModel.jl` version, use the
+`OMOPCommonDataModel.cdm_version` function:
+
+```jldoctest
+julia> using OMOPCommonDataModel
+
+julia> OMOPCommonDataModel.version()
+v"0.1.0-DEV"
+```
+
+To see all versions of the Common Data Model, go to the
+[CommonDataModel release page](https://github.com/OHDSI/CommonDataModel/releases).
+
+To see all versions of `OMOPCommonDataModel.jl`, go to the
+[`OMOPCommonDataModel.jl` release page](https://github.com/JuliaHealth/OMOPCommonDataModel.jl/releases).

--- a/src/OMOPCommonDataModel.jl
+++ b/src/OMOPCommonDataModel.jl
@@ -5,10 +5,8 @@ import DocStringExtensions
 
 abstract type OmopType end
 
-"""
-The version of the OMOP Common Data Model (CDM) being implemented.
-"""
 const CDM_VERSION = v"6.0.0"
+include("version.jl")
 
 # Standardized Vocabularies
 # export Concept

--- a/src/version.jl
+++ b/src/version.jl
@@ -1,0 +1,19 @@
+import Pkg
+
+"""
+The version of the OMOPCommonDataModel.jl package.
+"""
+function version()::VersionNumber
+    package_directory = dirname(dirname(@__FILE__))
+    project_file = joinpath(package_directory, "Project.toml")
+    version_string = Pkg.TOML.parsefile(project_file)["version"]
+    version_number = VersionNumber(version_string)
+    return version_number
+end
+
+"""
+The version of the OMOP Common Data Model (CDM) being implemented.
+"""
+@inline function cdm_version()::VersionNumber
+    return CDM_VERSION
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,21 @@ using PrettyPrint
 using StructArrays
 using Test
 
+using OMOPCommonDataModel
+
+using Test
+
+
 @testset "OMOPCommonDataModel.jl" begin
+    @testset "Unit tests" begin
+        @testset "version" begin
+            @test OMOPCommonDataModel.version() isa VersionNumber
+            @test OMOPCommonDataModel.version() > v"0"
+            @test OMOPCommonDataModel.cdm_version() isa VersionNumber
+            @test OMOPCommonDataModel.cdm_version() > v"0"
+            @test OMOPCommonDataModel.cdm_version() == OMOPCommonDataModel.CDM_VERSION
+        end
+    end
     @testset "Doctests" begin
         doctest(OMOPCommonDataModel)
     end


### PR DESCRIPTION
We will recommend that users use the `cdm_version` function instead.